### PR TITLE
Cypress version 6.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,10 @@ RUN apt-get install -y rsync
 # avoid too many progress messages
 # https://github.com/cypress-io/cypress/issues/1243
 ENV CI=1
-ARG CYPRESS_VERSION="5.6.0"
+ARG CYPRESS_VERSION="6.3.0"
 
 RUN unset PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
-RUN npm install cypress@5.6.0 start-server-and-test@^1.11.5 @percy/cypress puppeteer --unsafe-perm=true
+RUN npm install cypress@6.3.0 start-server-and-test@^1.11.7 @percy/cypress puppeteer --unsafe-perm=true
 
 RUN echo "whoami: $(whoami)"
 RUN npm config -g set user $(whoami)


### PR DESCRIPTION
- Bumping Cypress to 6.3.0
- Bumping start-server-and-test to 1.11.7