### PR TITLE
Bumping cypress to 7.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     libpng-dev \
     build-essential
 
-RUN npm install -g npm@6.14.8
+RUN npm install -g npm@7.6.2
 
 USER root
 
@@ -43,10 +43,10 @@ RUN apt-get install -y rsync
 # avoid too many progress messages
 # https://github.com/cypress-io/cypress/issues/1243
 ENV CI=1
-ARG CYPRESS_VERSION="6.5.0"
+ARG CYPRESS_VERSION="7.0.0"
 
 RUN unset PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
-RUN npm install cypress@6.5.0 start-server-and-test@^1.11.7 @percy/cypress puppeteer --unsafe-perm=true
+RUN npm install cypress@7.0.0 start-server-and-test@^1.12.1 @percy/cypress puppeteer --unsafe-perm=true
 
 RUN echo "whoami: $(whoami)"
 RUN npm config -g set user $(whoami)


### PR DESCRIPTION
Bumping:

- Cypress to 7.0.0
- start-server-and-test to 1.12.1
- npm to 7.6.2