### PR TITLE
fix: specify working directory for running npm install correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16.13.0
 
+WORKDIR /usr/app
+
 RUN apt-get update && \
   apt-get install -y \
   libgtk2.0-0 \
@@ -11,7 +13,7 @@ RUN apt-get update && \
   xvfb \
   libpng-dev \
   build-essential \
-  openjdk-8-jre
+  openjdk-11-jre
 
 RUN npm install -g npm@8.1.0
 


### PR DESCRIPTION
Since node v15, it is necessary to specify the WORKDIR on the docker file in order to rum `npm install` commands.
[Thread on stack overflow](https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for)

Also, for docker image node:16.13.0 the openJDK version should be 11, not 8.